### PR TITLE
fix 移除复制curl时的头部空行

### DIFF
--- a/src/components/CurlLocalRequest/request/UrlSend.vue
+++ b/src/components/CurlLocalRequest/request/UrlSend.vue
@@ -136,7 +136,7 @@ export default {
         body: this.$store.state.curl.request.body
       };
       const curlStringOptions = {colorJson: false, jsonIndentWidth: 2}
-      window.utools.copyText(curlString(url, options, curlStringOptions))
+      window.utools.copyText(curlString(url, options, curlStringOptions).trim())
       ElMessage({
         message: '复制成功',
         type: 'success',


### PR DESCRIPTION
避免经过curl处理后的数据，curl自己无法识别进入插件